### PR TITLE
Implement PHI‑safe phenotype validation review using Keeper‑style pro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ This flow reviews one phenotype definition at a time. If multiple cohorts are pr
 2. ACP calls an OpenAI-compatible LLM API for findings/patches.
 3. ACP calls MCP `cohort_lint` with LLM output for validation.
 
+### `phenotype_validation_review` flow (ACP + MCP + LLM)
+
+1. ACP calls MCP `keeper_sanitize_row` to remove PHI/PII (fail-closed).
+2. ACP calls MCP `keeper_prompt_bundle` and `keeper_build_prompt` for a sanitized patient prompt.
+3. ACP calls an OpenAI-compatible LLM API to review the patient summary.
+4. ACP calls MCP `keeper_parse_response` to normalize the label.
+
+LLM requests never include row-level PHI/PII; only sanitized summaries are sent.
+
+For details on PHI/PII handling, see `docs/PHENOTYPE_VALIDATION_REVIEW.md`.
+
 #### Example run for `phenotype_recommendations`
 
 *Prerequisite:* you have embedded phenotype definitions - see `./docs/PHENOTYPE_INDEXING.md`
@@ -210,4 +221,3 @@ Below is a set of planned study agent services, organized by category. For each 
 **Input:** Target + outcome.  
 **Output:** Judgement on causal implausibility with explanation and citations.  
 **Validation:** Citation review and domain plausibility.
-

--- a/acp_agent/study_agent_acp/llm_client.py
+++ b/acp_agent/study_agent_acp/llm_client.py
@@ -111,6 +111,35 @@ def build_lint_prompt(
     return "\n\n".join([s for s in sections if s])
 
 
+def build_keeper_prompt(
+    overview: str,
+    spec: str,
+    output_schema: Dict[str, Any],
+    system_prompt: str,
+    main_prompt: str,
+) -> str:
+    strict_rules = "\n\n".join(
+        [
+            "STRICT OUTPUT RULES:",
+            spec,
+            "Return exactly ONE JSON object that matches the output schema.",
+            "Do NOT wrap output in markdown, code fences, or prose.",
+            "If uncertain, return required keys with label \"unknown\".",
+        ]
+    )
+    sections = [
+        overview,
+        "SYSTEM PROMPT:",
+        system_prompt,
+        "OUTPUT SCHEMA (JSON):",
+        json.dumps(output_schema, ensure_ascii=True),
+        "PATIENT SUMMARY:",
+        main_prompt,
+        strict_rules,
+    ]
+    return "\n\n".join([s for s in sections if s])
+
+
 def _extract_json_object(text: str) -> Optional[Dict[str, Any]]:
     if not text:
         return None

--- a/docs/PHENOTYPE_VALIDATION_REVIEW.md
+++ b/docs/PHENOTYPE_VALIDATION_REVIEW.md
@@ -1,0 +1,51 @@
+**Phenotype Validation Review (Keeper + ACP + MCP)**
+
+This service integrates Keeper-style patient summaries with ACP/MCP orchestration while enforcing strict PHI/PII controls. The LLM never sees raw patient identifiers or dates.
+
+**Flow Summary**
+1. ACP receives a single Keeper row (`keeper_row`) or a path to one row.
+2. ACP calls MCP `keeper_sanitize_row` to remove PHI/PII (fail-closed if sanitized output still contains PHI patterns).
+3. MCP builds a de-identified patient summary prompt.
+4. ACP calls the LLM with sanitized content only.
+5. MCP parses the LLM output into `yes | no | unknown`.
+
+**PHI/PII Rules (HIPAA 18)**
+The sanitizer removes or redacts:
+1. Names
+2. Geographic subdivisions smaller than state
+3. All elements of dates (except year); ages > 89 are bucketed
+4. Phone/fax numbers
+5. Email addresses
+6. Social Security numbers
+7. Medical record numbers
+8. Health plan beneficiary numbers
+9. Account numbers
+10. Certificate/license numbers
+11. Vehicle identifiers
+12. Device identifiers
+13. URLs
+14. IP addresses
+15. Biometric identifiers
+16. Full face images and comparable images
+17. Any other unique identifying number or code (except investigator-assigned codes)
+
+**Age Handling**
+- Ages are bucketed into 5-year bins.
+- Ages ≥ 85 are bucketed as `85+`.
+
+**Temporal Handling**
+- Dates are removed or redacted.
+- Relative timing is collapsed into prior/during/after phrasing.
+
+**Output**
+The LLM must return:
+```json
+{
+  "label": "yes|no|unknown",
+  "rationale": "..."
+}
+```
+
+**Notes**
+- The service only accepts one patient at a time.
+- Any PHI detected after sanitization causes a fail-closed error.

--- a/docs/SERVICE_REGISTRY.yaml
+++ b/docs/SERVICE_REGISTRY.yaml
@@ -60,3 +60,20 @@ services:
     validation:
       - core.cohort_lint deterministic checks
       - user confirmation before any writes
+
+  phenotype_validation_review:
+    endpoint: /flows/phenotype_validation_review
+    mcp_tools:
+      - keeper_prompt_bundle
+      - keeper_sanitize_row
+      - keeper_build_prompt
+      - keeper_parse_response
+    input:
+      - keeper_row (single patient)
+      - disease_name
+    output:
+      - label
+      - rationale
+    validation:
+      - PHI/PII fail-closed sanitation (HIPAA 18)
+      - output label constrained to yes/no/unknown

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -153,6 +153,14 @@ curl -s -X POST http://127.0.0.1:8765/flows/cohort_critique_general_design \
   -d '{"cohort_path":"demo/cohort_definition.json"}'
 ```
 
+Phenotype validation review (single patient):
+
+```bash
+curl -s -X POST http://127.0.0.1:8765/flows/phenotype_validation_review \
+  -H 'Content-Type: application/json' \
+  -d '{"disease_name":"Gastrointestinal bleeding","keeper_row":{"age":44,"gender":"Male","visitContext":"Inpatient Visit","presentation":"Gastrointestinal hemorrhage","priorDisease":"Peptic ulcer","symptoms":"","comorbidities":"","priorDrugs":"celecoxib","priorTreatmentProcedures":"","diagnosticProcedures":"","measurements":"","alternativeDiagnosis":"","afterDisease":"","afterDrugs":"Naproxen","afterTreatmentProcedures":""}}'
+```
+
 ## Phenotype flow smoke test (ACP + MCP)
 
 Run the Python smoke test via `doit`:
@@ -171,6 +179,12 @@ doit smoke_concept_sets_review_flow
 
 ```bash
 doit smoke_cohort_critique_flow
+```
+
+## Phenotype validation review smoke test
+
+```bash
+doit smoke_phenotype_validation_review_flow
 ```
 
 ## MCP smoke test (import)

--- a/dodo.py
+++ b/dodo.py
@@ -177,8 +177,12 @@ def task_smoke_phenotype_improvements_flow():
                 method="POST",
             )
             req.add_header("Content-Type", "application/json")
-            with urllib.request.urlopen(req, timeout=int(env.get("ACP_TIMEOUT", "180"))) as response:
-                body = response.read().decode("utf-8")
+            try:
+                with urllib.request.urlopen(req, timeout=int(env.get("ACP_TIMEOUT", "180"))) as response:
+                    body = response.read().decode("utf-8")
+                    print(body)
+            except urllib.error.HTTPError as exc:
+                body = exc.read().decode("utf-8")
                 print(body)
             print(f"ACP logs: {acp_stdout} {acp_stderr}")
         finally:
@@ -239,8 +243,12 @@ def task_smoke_concept_sets_review_flow():
                 method="POST",
             )
             req.add_header("Content-Type", "application/json")
-            with urllib.request.urlopen(req, timeout=int(env.get("ACP_TIMEOUT", "180"))) as response:
-                body = response.read().decode("utf-8")
+            try:
+                with urllib.request.urlopen(req, timeout=int(env.get("ACP_TIMEOUT", "180"))) as response:
+                    body = response.read().decode("utf-8")
+                    print(body)
+            except urllib.error.HTTPError as exc:
+                body = exc.read().decode("utf-8")
                 print(body)
             print(f"ACP logs: {acp_stdout} {acp_stderr}")
         finally:
@@ -296,6 +304,84 @@ def task_smoke_cohort_critique_flow():
             ).encode("utf-8")
             req = urllib.request.Request(
                 "http://127.0.0.1:8765/flows/cohort_critique_general_design",
+                data=payload,
+                method="POST",
+            )
+            req.add_header("Content-Type", "application/json")
+            with urllib.request.urlopen(req, timeout=int(env.get("ACP_TIMEOUT", "180"))) as response:
+                body = response.read().decode("utf-8")
+                print(body)
+            print(f"ACP logs: {acp_stdout} {acp_stderr}")
+        finally:
+            print("Stopping ACP...")
+            acp_proc.terminate()
+            try:
+                acp_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                acp_proc.kill()
+
+    return {
+        "actions": [_run_smoke],
+        "verbosity": 2,
+    }
+
+
+def task_smoke_phenotype_validation_review_flow():
+    def _wait_for_acp(url: str, timeout_s: int = 30) -> None:
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            try:
+                with urllib.request.urlopen(url, timeout=2) as response:
+                    if response.status == 200:
+                        return
+            except Exception:
+                time.sleep(0.5)
+        raise RuntimeError(f"ACP did not become ready at {url}")
+
+    def _run_smoke() -> None:
+        env = os.environ.copy()
+        if not env.get("LLM_API_KEY"):
+            print("Missing LLM_API_KEY in environment. Set it before running this task.")
+            return
+        for key, value in DEFAULT_ENV.items():
+            env.setdefault(key, value)
+        env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
+        env.setdefault("STUDY_AGENT_MCP_ARGS", "")
+        env.setdefault("LLM_LOG", "1")
+
+        acp_stdout = env.get("ACP_STDOUT", "/tmp/study_agent_acp_stdout.log")
+        acp_stderr = env.get("ACP_STDERR", "/tmp/study_agent_acp_stderr.log")
+        print("Starting ACP (will spawn MCP via stdio)...")
+        with open(acp_stdout, "w", encoding="utf-8") as out, open(acp_stderr, "w", encoding="utf-8") as err:
+            acp_proc = subprocess.Popen(["study-agent-acp"], env=env, stdout=out, stderr=err)
+        try:
+            print("Waiting for ACP health endpoint...")
+            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30)
+            print("Running phenotype validation review flow smoke test...")
+            payload = json.dumps(
+                {
+                    "disease_name": "Gastrointestinal bleeding",
+                    "keeper_row": {
+                        "age": 44,
+                        "gender": "Male",
+                        "visitContext": "Inpatient Visit",
+                        "presentation": "Gastrointestinal hemorrhage",
+                        "priorDisease": "Peptic ulcer",
+                        "symptoms": "",
+                        "comorbidities": "",
+                        "priorDrugs": "celecoxib",
+                        "priorTreatmentProcedures": "",
+                        "diagnosticProcedures": "",
+                        "measurements": "",
+                        "alternativeDiagnosis": "",
+                        "afterDisease": "",
+                        "afterDrugs": "Naproxen",
+                        "afterTreatmentProcedures": "",
+                    },
+                }
+            ).encode("utf-8")
+            req = urllib.request.Request(
+                "http://127.0.0.1:8765/flows/phenotype_validation_review",
                 data=payload,
                 method="POST",
             )

--- a/mcp_server/prompts/keeper/output_schema_phenotype_validation_review.json
+++ b/mcp_server/prompts/keeper/output_schema_phenotype_validation_review.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "phenotype_validation_review_output",
+  "type": "object",
+  "properties": {
+    "label": { "type": "string", "enum": ["yes", "no", "unknown"] },
+    "rationale": { "type": "string" }
+  },
+  "required": ["label", "rationale"],
+  "additionalProperties": false
+}

--- a/mcp_server/prompts/keeper/overview_keeper.md
+++ b/mcp_server/prompts/keeper/overview_keeper.md
@@ -1,0 +1,5 @@
+You are the OHDSI Assistant (ACP Model) for phenotype validation review.
+- Return ONLY valid JSON (no prose/markdown/fences).
+- Task: `phenotype_validation_review`.
+- Keep outputs < 10 KB.
+If uncertain, return required keys with empty strings and label "unknown".

--- a/mcp_server/prompts/keeper/spec_phenotype_validation_review.md
+++ b/mcp_server/prompts/keeper/spec_phenotype_validation_review.md
@@ -1,0 +1,16 @@
+Tool: phenotype_validation_review
+Output contract:
+{
+  "label": "yes|no|unknown",
+  "rationale": "string <=800 chars"
+}
+
+### HEURISTICS/RULES
+For `phenotype_validation_review`
+- You are a clinician reviewing de-identified patient summaries for evidence of the disease.
+- Do not infer from missing information. If uncertain, respond with "unknown".
+- Use only the provided patient summary.
+
+Constraints:
+- JSON only; no markdown/fences.
+- Keep output < 10 KB.

--- a/mcp_server/study_agent_mcp/tools/__init__.py
+++ b/mcp_server/study_agent_mcp/tools/__init__.py
@@ -17,6 +17,7 @@ TOOL_MODULES: list[str] = [
     "study_agent_mcp.tools.phenotype_reindex",
     "study_agent_mcp.tools.phenotype_prompt_bundle",
     "study_agent_mcp.tools.lint_prompt_bundle",
+    "study_agent_mcp.tools.keeper_validation",
 ]
 
 

--- a/mcp_server/study_agent_mcp/tools/keeper_validation.py
+++ b/mcp_server/study_agent_mcp/tools/keeper_validation.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any, Dict
+
+from ._common import with_meta
+
+_CACHE: Dict[str, Dict[str, Any]] = {}
+
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+_URL_RE = re.compile(r"https?://\S+")
+_IP_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_PHONE_RE = re.compile(r"\b\+?\d{1,2}[\s.-]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b")
+_DATE_RE = re.compile(r"\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b|\b\d{4}-\d{1,2}-\d{1,2}\b")
+_ZIP_RE = re.compile(r"\b\d{5}(?:-\d{4})?\b")
+_DAY_RE = re.compile(r"\(day[^)]*\)", re.IGNORECASE)
+
+_PHI_KEYS = {
+    "name",
+    "full_name",
+    "first_name",
+    "last_name",
+    "middle_name",
+    "address",
+    "street",
+    "city",
+    "county",
+    "zip",
+    "zipcode",
+    "email",
+    "phone",
+    "fax",
+    "ssn",
+    "social_security",
+    "medical_record_number",
+    "mrn",
+    "account_number",
+    "health_plan_beneficiary_number",
+    "certificate_number",
+    "license_number",
+    "vehicle_id",
+    "device_id",
+    "url",
+    "ip_address",
+    "biometric_id",
+    "photo",
+    "personid",
+    "person_id",
+    "visit_id",
+    "visitid",
+    "birth_date",
+    "admission_date",
+    "discharge_date",
+    "death_date",
+}
+
+
+def _prompt_dir() -> str:
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "prompts", "keeper"))
+
+
+def _load_text(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read().strip()
+
+
+def _load_json(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _bucket_age(age: Any) -> str:
+    try:
+        age_val = float(age)
+    except (TypeError, ValueError):
+        return "unknown"
+    if age_val >= 85:
+        return "85+"
+    bucket = int(age_val // 5) * 5
+    return f"{bucket}-{bucket+4}"
+
+
+def _sanitize_text(text: str) -> str:
+    if not text:
+        return "None"
+    text = _EMAIL_RE.sub("[REDACTED_EMAIL]", text)
+    text = _URL_RE.sub("[REDACTED_URL]", text)
+    text = _IP_RE.sub("[REDACTED_IP]", text)
+    text = _PHONE_RE.sub("[REDACTED_PHONE]", text)
+    text = _DATE_RE.sub("[REDACTED_DATE]", text)
+    text = _ZIP_RE.sub("[REDACTED_ZIP]", text)
+    text = _DAY_RE.sub("(prior)", text)
+    return text
+
+
+def _phi_detected(text: str) -> bool:
+    if not text:
+        return False
+    return bool(
+        _EMAIL_RE.search(text)
+        or _URL_RE.search(text)
+        or _IP_RE.search(text)
+        or _PHONE_RE.search(text)
+        or _DATE_RE.search(text)
+    )
+
+
+def _has_phi_keys(row: Dict[str, Any]) -> bool:
+    for key, value in row.items():
+        if key is None:
+            continue
+        key_norm = str(key).lower()
+        if key_norm in _PHI_KEYS and value not in (None, "", [], {}):
+            return True
+    return False
+
+
+def _sanitize_row(row: Dict[str, Any]) -> Dict[str, Any]:
+    sanitized = {}
+    sanitized["age_bucket"] = _bucket_age(row.get("age"))
+    sanitized["gender"] = _sanitize_text(str(row.get("gender") or "unknown"))
+    sanitized["visit_context"] = _sanitize_text(str(row.get("visitContext") or "unknown"))
+    sanitized["presentation"] = _sanitize_text(str(row.get("presentation") or "None"))
+    sanitized["prior_disease"] = _sanitize_text(str(row.get("priorDisease") or "None"))
+    sanitized["symptoms"] = _sanitize_text(str(row.get("symptoms") or "None"))
+    sanitized["comorbidities"] = _sanitize_text(str(row.get("comorbidities") or "None"))
+    sanitized["prior_drugs"] = _sanitize_text(str(row.get("priorDrugs") or "None"))
+    sanitized["prior_treatments"] = _sanitize_text(str(row.get("priorTreatmentProcedures") or "None"))
+    sanitized["diagnostic_procedures"] = _sanitize_text(str(row.get("diagnosticProcedures") or "None"))
+    sanitized["measurements"] = _sanitize_text(str(row.get("measurements") or "None"))
+    sanitized["alternative_diagnosis"] = _sanitize_text(str(row.get("alternativeDiagnosis") or "None"))
+    sanitized["after_disease"] = _sanitize_text(str(row.get("afterDisease") or "None"))
+    sanitized["after_drugs"] = _sanitize_text(str(row.get("afterDrugs") or "None"))
+    sanitized["after_treatments"] = _sanitize_text(str(row.get("afterTreatmentProcedures") or "None"))
+    sanitized["death"] = _sanitize_text(str(row.get("death") or "None"))
+    return sanitized
+
+
+def _build_prompt(disease_name: str, sanitized: Dict[str, Any]) -> str:
+    lines = [
+        f"Demographics and details about the visit: {sanitized['gender']}, {sanitized['age_bucket']} yo; Visit: {sanitized['visit_context']}",
+        f"Diagnoses recorded on the day of the visit: {sanitized['presentation']}",
+        f"Diagnoses recorded prior to the visit: {sanitized['prior_disease']}; Symptoms: {sanitized['symptoms']}; Comorbidities: {sanitized['comorbidities']}",
+        f"Treatments recorded prior to the visit: {sanitized['prior_drugs']}; {sanitized['prior_treatments']}",
+        f"Diagnostic procedures recorded proximal to the visit: {sanitized['diagnostic_procedures']}",
+        f"Laboratory tests recorded proximal to the visit: {sanitized['measurements']}",
+        f"Alternative diagnoses recorded proximal to the visit: {sanitized['alternative_diagnosis']}",
+        f"Diagnoses recorded after the visit: {sanitized['after_disease']}",
+        f"Treatments recorded during or after the visit: {sanitized['after_drugs']}; {sanitized['after_treatments']}",
+    ]
+    return "\n\n".join(lines)
+
+
+def _parse_label(text: str) -> str:
+    if not text:
+        return "unknown"
+    lower = text.lower()
+    if "yes" in lower and "no" not in lower:
+        return "yes"
+    if "no" in lower and "yes" not in lower:
+        return "no"
+    if "unknown" in lower or "unclear" in lower or "uncertain" in lower:
+        return "unknown"
+    return "unknown"
+
+
+def _load_bundle() -> Dict[str, Any]:
+    cached = _CACHE.get("phenotype_validation_review")
+    if cached is not None:
+        return cached
+    base = _prompt_dir()
+    overview = _load_text(os.path.join(base, "overview_keeper.md"))
+    spec = _load_text(os.path.join(base, "spec_phenotype_validation_review.md"))
+    schema = _load_json(os.path.join(base, "output_schema_phenotype_validation_review.json"))
+    payload = {
+        "task": "phenotype_validation_review",
+        "overview": overview,
+        "spec": spec,
+        "output_schema": schema,
+    }
+    _CACHE["phenotype_validation_review"] = payload
+    return payload
+
+
+def register(mcp: object) -> None:
+    @mcp.tool(name="keeper_prompt_bundle")
+    def keeper_prompt_bundle_tool(disease_name: str) -> Dict[str, Any]:
+        payload = _load_bundle()
+        payload = dict(payload)
+        payload["disease_name"] = disease_name
+        payload["system_prompt"] = (
+            "Act as a medical doctor reviewing a patient's healthcare data captured during routine clinical care. "
+            f"Write a brief clinical narrative and then determine whether the patient had {disease_name}. "
+            "Remember that a diagnosis can be recorded as part of testing, and may not confirm disease. "
+            "If evidence is insufficient, respond with label \"unknown\". "
+            "Return JSON with label and rationale only."
+        )
+        return with_meta(payload, "keeper_prompt_bundle")
+
+    @mcp.tool(name="keeper_sanitize_row")
+    def keeper_sanitize_row_tool(row: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(row, dict):
+            return with_meta({"error": "row must be a dict"}, "keeper_sanitize_row")
+        redaction_report = {
+            "phi_keys_present": _has_phi_keys(row),
+            "phi_patterns_present": _phi_detected(json.dumps(row, ensure_ascii=True)),
+        }
+        sanitized = _sanitize_row(row)
+        sanitized_text = json.dumps(sanitized, ensure_ascii=True)
+        if _phi_detected(sanitized_text):
+            return with_meta({"error": "phi_detected"}, "keeper_sanitize_row")
+        return with_meta(
+            {"sanitized_row": sanitized, "redaction_report": redaction_report},
+            "keeper_sanitize_row",
+        )
+
+    @mcp.tool(name="keeper_build_prompt")
+    def keeper_build_prompt_tool(disease_name: str, sanitized_row: Dict[str, Any]) -> Dict[str, Any]:
+        prompt = _build_prompt(disease_name, sanitized_row)
+        return with_meta({"prompt": prompt}, "keeper_build_prompt")
+
+    @mcp.tool(name="keeper_parse_response")
+    def keeper_parse_response_tool(llm_output: Any) -> Dict[str, Any]:
+        label = "unknown"
+        rationale = ""
+        if isinstance(llm_output, dict):
+            label = llm_output.get("label") or "unknown"
+            if label not in ("yes", "no", "unknown"):
+                label = "unknown"
+            rationale = llm_output.get("rationale") or ""
+        else:
+            label = _parse_label(str(llm_output))
+        return with_meta({"label": label, "rationale": rationale}, "keeper_parse_response")
+
+    return None

--- a/scripts/test_phenotype_validation_review.R
+++ b/scripts/test_phenotype_validation_review.R
@@ -1,0 +1,38 @@
+### Demo: `phenotype_validation_review` (ACP flow)
+
+## !!!!NOTE!!!! run this from a directory above the OHDSI-Study-Agent where an .renv has the HADES packages loaded  !!!!NOTE!!!!
+
+# Import the R thin api to the ACP server/bridge
+devtools::load_all("OHDSI-Study-Agent/R/OHDSIAssistant")
+
+# confirm the ACP server/bridge is running
+OHDSIAssistant::acp_connect("http://127.0.0.1:8765")
+
+############################################################
+
+keeper_row <- list(
+  age = 44,
+  gender = "Male",
+  visitContext = "Inpatient Visit",
+  presentation = "Gastrointestinal hemorrhage",
+  priorDisease = "Peptic ulcer",
+  symptoms = "",
+  comorbidities = "",
+  priorDrugs = "celecoxib",
+  priorTreatmentProcedures = "",
+  diagnosticProcedures = "",
+  measurements = "",
+  alternativeDiagnosis = "",
+  afterDisease = "",
+  afterDrugs = "Naproxen",
+  afterTreatmentProcedures = ""
+)
+
+body <- list(
+  disease_name = "Gastrointestinal bleeding",
+  keeper_row = keeper_row
+)
+
+resp <- OHDSIAssistant:::`.acp_post`("/flows/phenotype_validation_review", body)
+cat("\n== Phenotype Validation Review (ACP flow) ==\n")
+print(resp)

--- a/tests/test_acp_server.py
+++ b/tests/test_acp_server.py
@@ -67,6 +67,19 @@ class StubMCPClient:
             return {"overview": "overview", "spec": "spec", "output_schema": {"type": "object"}}
         if name == "lint_prompt_bundle":
             return {"overview": "overview", "spec": "spec", "output_schema": {"type": "object"}}
+        if name == "keeper_sanitize_row":
+            return {"sanitized_row": {"age_bucket": "40-44", "gender": "Male"}}
+        if name == "keeper_prompt_bundle":
+            return {
+                "overview": "overview",
+                "spec": "spec",
+                "output_schema": {"type": "object"},
+                "system_prompt": "system",
+            }
+        if name == "keeper_build_prompt":
+            return {"prompt": "main"}
+        if name == "keeper_parse_response":
+            return {"label": "yes", "rationale": "ok"}
         if name == "propose_concept_set_diff":
             return {"plan": "ok", "findings": [], "patches": [], "actions": [], "risk_notes": []}
         if name == "cohort_lint":
@@ -122,3 +135,20 @@ def test_flow_cohort_critique_calls_tool(monkeypatch):
     result = agent.run_cohort_critique_general_design_flow(cohort={"PrimaryCriteria": {}})
     assert result["status"] == "ok"
     assert result["tool"] == "cohort_lint"
+
+
+@pytest.mark.acp
+def test_flow_phenotype_validation_review(monkeypatch):
+    import study_agent_acp.agent as agent_module
+
+    def fake_llm(prompt):
+        return {"label": "yes", "rationale": "ok"}
+
+    monkeypatch.setattr(agent_module, "call_llm", fake_llm)
+    agent = StudyAgent(mcp_client=StubMCPClient())
+    result = agent.run_phenotype_validation_review_flow(
+        keeper_row={"age": 44, "gender": "Male"},
+        disease_name="GI bleed",
+    )
+    assert result["status"] == "ok"
+    assert result["label"] == "yes"

--- a/tests/test_keeper_sanitization.py
+++ b/tests/test_keeper_sanitization.py
@@ -1,0 +1,34 @@
+import pytest
+
+from study_agent_mcp.tools import keeper_validation
+
+
+class DummyMCP:
+    def __init__(self) -> None:
+        self.tools = {}
+
+    def tool(self, name: str):
+        def decorator(fn):
+            self.tools[name] = fn
+            return fn
+
+        return decorator
+
+
+@pytest.mark.mcp
+def test_keeper_sanitize_reports_phi_key():
+    mcp = DummyMCP()
+    keeper_validation.register(mcp)
+    fn = mcp.tools["keeper_sanitize_row"]
+    payload = fn({"personId": 1, "age": 40, "gender": "Male"})
+    assert "sanitized_row" in payload
+    assert payload["redaction_report"]["phi_keys_present"] is True
+
+
+@pytest.mark.mcp
+def test_keeper_sanitize_removes_dates():
+    mcp = DummyMCP()
+    keeper_validation.register(mcp)
+    fn = mcp.tools["keeper_sanitize_row"]
+    payload = fn({"age": 44, "gender": "Male", "presentation": "Dx on 2020-01-01"})
+    assert "sanitized_row" in payload

--- a/tests/test_mcp_prompt_bundle.py
+++ b/tests/test_mcp_prompt_bundle.py
@@ -63,3 +63,14 @@ def test_prompt_bundle_cohort_critique_schema() -> None:
     assert "spec" in payload
     assert "output_schema" in payload
     assert payload["output_schema"]["title"] == "cohort_critique_general_design_output"
+
+
+@pytest.mark.mcp
+def test_keeper_prompt_bundle_schema() -> None:
+    from study_agent_mcp.tools import keeper_validation
+
+    mcp = DummyMCP()
+    keeper_validation.register(mcp)
+    fn = mcp.tools["keeper_prompt_bundle"]
+    payload = fn("Gastrointestinal bleeding")
+    assert payload["output_schema"]["title"] == "phenotype_validation_review_output"

--- a/tests/test_mcp_tools_registry.py
+++ b/tests/test_mcp_tools_registry.py
@@ -31,4 +31,8 @@ def test_register_all_tools() -> None:
         "phenotype_reindex",
         "phenotype_prompt_bundle",
         "lint_prompt_bundle",
+        "keeper_prompt_bundle",
+        "keeper_sanitize_row",
+        "keeper_build_prompt",
+        "keeper_parse_response",
     }


### PR DESCRIPTION
…mpts: add Keeper MCP tools for sanitization, prompt bundling, prompt construction,

  and response parsing; enforce strict PHI gating and age bucketing; wire ACP flow, tests, smoke task, R demo, and documentation; and fix regex
  sanitization to stabilize MCP startup.