### PR TITLE
Add HTTP MCP option, improve diagnostics, and harden smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+demo-strategus-cohort-incidence/*
+conda-pip-env-github-workflow.yml
 *sandbox*
 *.doit.db*
 *data*

--- a/README.md
+++ b/README.md
@@ -126,10 +126,46 @@ export STUDY_AGENT_MCP_COMMAND=study-agent-mcp
 export STUDY_AGENT_MCP_ARGS=""
 study-agent-acp
 ```
+Note: This starts MCP via stdio. If you use MCP over HTTP, do not set `STUDY_AGENT_MCP_COMMAND`.
 Note: Prefer stopping the ACP process (SIGINT/SIGTERM) so the MCP subprocess is closed cleanly. Killing the MCP directly can leave defunct processes.
 Note: ACP uses a threaded HTTP server by default. Set `STUDY_AGENT_THREADING=0` to disable threading.
 Note: `/health` includes MCP preflight details under `mcp_index` when MCP is configured.
 Troubleshooting: run `python mcp_server/scripts/mcp_probe.py` to verify index paths and search without ACP.
+
+### MCP over HTTP (recommended for cross-platform stability)
+
+Start MCP as a separate HTTP service:
+
+```bash
+export MCP_TRANSPORT=http
+export MCP_HOST=127.0.0.1
+export MCP_PORT=8790
+export MCP_PATH=/mcp
+study-agent-mcp
+```
+
+Then point ACP at it:
+
+```bash
+export STUDY_AGENT_MCP_URL="http://127.0.0.1:8790/mcp"
+study-agent-acp
+```
+Note: `STUDY_AGENT_MCP_URL` must include the port (e.g. `:8790`). When set, ACP uses HTTP and ignores `STUDY_AGENT_MCP_COMMAND`.
+
+PowerShell (Windows) quickstart:
+
+```powershell
+$env:MCP_TRANSPORT = "http"
+$env:MCP_HOST = "127.0.0.1"
+$env:MCP_PORT = "8790"
+$env:MCP_PATH = "/mcp"
+study-agent-mcp
+```
+
+```powershell
+$env:STUDY_AGENT_MCP_URL = "http://127.0.0.1:8790/mcp"
+study-agent-acp
+```
 
 2. Run `phenotype_recommendation`
 ```bash

--- a/acp_agent/study_agent_acp/agent.py
+++ b/acp_agent/study_agent_acp/agent.py
@@ -273,6 +273,7 @@ class StudyAgent:
             return {"status": "error", "error": "missing study_intent"}
         if self._mcp_client is None:
             return {"status": "error", "error": "MCP client unavailable"}
+        debug = os.getenv("STUDY_AGENT_DEBUG", "0") == "1"
 
         prompt_bundle = self.call_tool(
             name="phenotype_intent_split",
@@ -292,7 +293,11 @@ class StudyAgent:
             output_schema=prompt_full.get("output_schema", {}),
             study_intent=study_intent,
         )
+        if debug:
+            print("ACP DEBUG > phenotype_intent_split: calling LLM")
         llm_result = call_llm(prompt)
+        if debug:
+            print("ACP DEBUG > phenotype_intent_split: LLM returned")
         if llm_result is None:
             return {
                 "status": "error",

--- a/acp_agent/study_agent_acp/llm_client.py
+++ b/acp_agent/study_agent_acp/llm_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 import urllib.error
 import urllib.request
 from typing import Any, Dict, Optional
@@ -222,6 +223,9 @@ def call_llm(prompt: str) -> Optional[Dict[str, Any]]:
     model = os.getenv("LLM_MODEL", "agentstudyassistant")
     timeout = int(os.getenv("LLM_TIMEOUT", "180"))
     log_enabled = os.getenv("LLM_LOG", "0") == "1"
+    log_prompt = os.getenv("LLM_LOG_PROMPT", "0") == "1"
+    log_response = os.getenv("LLM_LOG_RESPONSE", "0") == "1"
+    log_json = os.getenv("LLM_LOG_JSON", "0") == "1"
     dry_run = os.getenv("LLM_DRY_RUN", "0") == "1"
     use_responses = os.getenv("LLM_USE_RESPONSES", "0") == "1"
 
@@ -229,7 +233,7 @@ def call_llm(prompt: str) -> Optional[Dict[str, Any]]:
         print(f"LLM CONFIG > url={api_url} model={model} timeout={timeout} responses={use_responses}")
 
     if dry_run:
-        if log_enabled:
+        if log_enabled or log_prompt:
             print("LLM DRY RUN > skipping API call")
             print("LLM OUTGOING PROMPT >", prompt)
         return None
@@ -257,15 +261,18 @@ def call_llm(prompt: str) -> Optional[Dict[str, Any]]:
     request.add_header("Content-Type", "application/json")
     request.add_header("Authorization", f"Bearer {api_key}")
 
-    if log_enabled:
+    if log_enabled or log_prompt:
         print("LLM OUTGOING PROMPT >", prompt)
 
     try:
+        start = time.time()
         with urllib.request.urlopen(request, timeout=timeout) as response:
             raw = response.read().decode("utf-8")
+        if log_enabled:
+            print(f"LLM TIMING > seconds={time.time() - start:.2f}")
     except urllib.error.HTTPError as exc:
         raw = exc.read().decode("utf-8")
-        if log_enabled:
+        if log_enabled or log_response:
             print(f"LLM HTTP ERROR > {exc.code}")
             print("LLM ERROR BODY >", raw)
         return None
@@ -274,13 +281,15 @@ def call_llm(prompt: str) -> Optional[Dict[str, Any]]:
             print(f"LLM ERROR > {exc}")
         return None
 
-    if log_enabled:
+    if log_enabled or log_response:
         print("LLM RAW RESPONSE >", raw)
 
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
         return _extract_json_object(raw)
+    if log_json:
+        print("LLM JSON >", data)
 
     if use_responses:
         output_text = None

--- a/acp_agent/study_agent_acp/mcp_client.py
+++ b/acp_agent/study_agent_acp/mcp_client.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 import os
+import socket
 from threading import Lock
 from typing import Any, Dict, List, Optional
 
 import anyio
+import httpx
+from urllib.parse import urlparse
 from anyio.from_thread import start_blocking_portal
 from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 
 @dataclass
@@ -184,3 +189,110 @@ def _should_use_oneshot(exc: Exception) -> bool:
     if "GeneratorContextManager" in message:
         return True
     return False
+
+
+@dataclass
+class HttpMCPClientConfig:
+    url: str
+    token: Optional[str] = None
+    timeout: int = 30
+
+
+class HttpMCPClient:
+    def __init__(self, config: HttpMCPClientConfig) -> None:
+        if "://" not in config.url:
+            config.url = f"http://{config.url}"
+        self._config = config
+        parsed = urlparse(config.url)
+        self._host = parsed.hostname
+        self._port = parsed.port
+        self._lock = Lock()
+        self._portal = None
+        self._portal_cm = None
+        self._session: ClientSession | None = None
+        self._exit_stack: AsyncExitStack | None = None
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        self._ensure_session()
+        assert self._portal is not None
+        return self._portal.call(self._list_tools)
+
+    def call_tool(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        self._ensure_session()
+        assert self._portal is not None
+        return self._portal.call(self._call_tool, name, arguments)
+
+    def health_check(self) -> Dict[str, Any]:
+        if self._host and self._port:
+            try:
+                with socket.create_connection((self._host, self._port), timeout=1):
+                    return {"ok": True, "mode": "http"}
+            except OSError as exc:
+                return {"ok": False, "error": str(exc)}
+        try:
+            self._ensure_session()
+            assert self._portal is not None
+            return self._portal.call(self._ping)
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
+    async def _list_tools(self) -> List[Dict[str, Any]]:
+        assert self._session is not None
+        result = await self._session.list_tools()
+        return [tool.model_dump() for tool in result.tools]
+
+    async def _call_tool(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        assert self._session is not None
+        result = await self._session.call_tool(name=name, arguments=arguments)
+        if result.structuredContent is not None:
+            return result.structuredContent
+        return {"content": [c.model_dump() for c in result.content or []]}
+
+    async def _ping(self) -> Dict[str, Any]:
+        assert self._session is not None
+        await self._session.send_ping()
+        return {"ok": True, "mode": "http"}
+
+    def _ensure_session(self) -> None:
+        if self._session is not None:
+            return
+        with self._lock:
+            if self._session is not None:
+                return
+            self._portal_cm = start_blocking_portal()
+            self._portal = self._portal_cm.__enter__()
+            assert self._portal is not None
+            self._portal.call(self._async_init)
+
+    async def _async_init(self) -> None:
+        headers = {}
+        if self._config.token:
+            headers["Authorization"] = f"Bearer {self._config.token}"
+        timeout = httpx.Timeout(self._config.timeout)
+        client = create_mcp_http_client(headers=headers, timeout=timeout)
+        self._exit_stack = AsyncExitStack()
+        await self._exit_stack.enter_async_context(client)
+        read_stream, write_stream, _ = await self._exit_stack.enter_async_context(
+            streamable_http_client(self._config.url, http_client=client)
+        )
+        session = ClientSession(read_stream, write_stream)
+        await self._exit_stack.enter_async_context(session)
+        await session.initialize()
+        self._session = session
+
+    def close(self) -> None:
+        if self._portal is None:
+            return
+        try:
+            self._portal.call(self._async_close)
+        finally:
+            if self._portal_cm is not None:
+                self._portal_cm.__exit__(None, None, None)
+                self._portal_cm = None
+            self._portal = None
+
+    async def _async_close(self) -> None:
+        if self._exit_stack is not None:
+            await self._exit_stack.aclose()
+        self._exit_stack = None
+        self._session = None

--- a/acp_agent/study_agent_acp/server.py
+++ b/acp_agent/study_agent_acp/server.py
@@ -6,7 +6,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from typing import Any, Dict, Optional
 
 from .agent import StudyAgent
-from .mcp_client import StdioMCPClient, StdioMCPClientConfig
+from .mcp_client import HttpMCPClient, HttpMCPClientConfig, StdioMCPClient, StdioMCPClientConfig
 
 SERVICES = [
     {"name": "phenotype_recommendation", "endpoint": "/flows/phenotype_recommendation"},
@@ -70,7 +70,7 @@ def _load_registry_services() -> tuple[list[Dict[str, Any]], list[str]]:
 
 class ACPRequestHandler(BaseHTTPRequestHandler):
     agent: StudyAgent
-    mcp_client: Optional[StdioMCPClient]
+    mcp_client: Optional[object]
     debug: bool = False
 
     def log_message(self, format: str, *args: Any) -> None:
@@ -383,9 +383,14 @@ def _build_agent(
     mcp_args: Optional[list[str]],
     allow_core_fallback: bool,
     mcp_cwd: Optional[str],
-) -> tuple[StudyAgent, Optional[StdioMCPClient]]:
+    mcp_url: Optional[str],
+    mcp_token: Optional[str],
+    mcp_timeout: int,
+) -> tuple[StudyAgent, Optional[object]]:
     mcp_client = None
-    if mcp_command:
+    if mcp_url:
+        mcp_client = HttpMCPClient(HttpMCPClientConfig(url=mcp_url, token=mcp_token, timeout=mcp_timeout))
+    elif mcp_command:
         mcp_client = StdioMCPClient(
             StdioMCPClientConfig(command=mcp_command, args=mcp_args or [], cwd=mcp_cwd),
         )
@@ -457,8 +462,15 @@ def main(host: str = "127.0.0.1", port: int = 8765) -> None:
     debug = os.getenv("STUDY_AGENT_DEBUG", "0") == "1"
     threaded = os.getenv("STUDY_AGENT_THREADING", "1") == "1"
     mcp_cwd = os.getenv("STUDY_AGENT_MCP_CWD") or os.getcwd()
+    mcp_url = os.getenv("STUDY_AGENT_MCP_URL")
+    mcp_token = os.getenv("STUDY_AGENT_MCP_TOKEN")
+    mcp_timeout = int(os.getenv("STUDY_AGENT_MCP_TIMEOUT", "30"))
 
-    if mcp_command:
+    if mcp_url:
+        if "://" in mcp_url and ":" not in mcp_url.split("://", 1)[1]:
+            raise RuntimeError("STUDY_AGENT_MCP_URL missing port (e.g., http://127.0.0.1:8790/mcp).")
+        print(f"ACP INFO > MCP url={mcp_url}")
+    elif mcp_command:
         if os.getenv("PHENOTYPE_INDEX_DIR") is None:
             print("ACP WARN > PHENOTYPE_INDEX_DIR not set; MCP will use its default.")
         if os.getenv("EMBED_URL") is None:
@@ -468,7 +480,15 @@ def main(host: str = "127.0.0.1", port: int = 8765) -> None:
         print(f"ACP INFO > MCP cwd={mcp_cwd}")
 
     args_list = [arg for arg in mcp_args.split(" ") if arg]
-    agent, mcp_client = _build_agent(mcp_command, args_list, allow_core_fallback, mcp_cwd)
+    agent, mcp_client = _build_agent(
+        mcp_command,
+        args_list,
+        allow_core_fallback,
+        mcp_cwd,
+        mcp_url,
+        mcp_token,
+        mcp_timeout,
+    )
 
     class Handler(ACPRequestHandler):
         agent = None
@@ -504,7 +524,7 @@ def main(host: str = "127.0.0.1", port: int = 8765) -> None:
     _serve(server, mcp_client)
 
 
-def _serve(server: HTTPServer, mcp_client: Optional[StdioMCPClient]) -> None:
+def _serve(server: HTTPServer, mcp_client: Optional[object]) -> None:
     try:
         server.serve_forever()
     finally:

--- a/docs/PHENOTYPE_RECOMMENDATION_DESIGN.md
+++ b/docs/PHENOTYPE_RECOMMENDATION_DESIGN.md
@@ -121,6 +121,9 @@ Candidate selection:
 19. `STUDY_AGENT_PORT` (default `8765`)
 20. `STUDY_AGENT_MCP_CWD` (optional) working directory passed to MCP subprocesses. Use for stable relative paths.
 21. `MCP_LOG_LEVEL` (default `INFO`) controls MCP stderr logging (`DEBUG|INFO|WARN|ERROR|OFF`).
+22. `STUDY_AGENT_MCP_URL` (optional) HTTP MCP endpoint. When set, ACP uses HTTP and ignores `STUDY_AGENT_MCP_COMMAND`.
+23. `STUDY_AGENT_MCP_TOKEN` (optional) bearer token passed to MCP over HTTP.
+24. `STUDY_AGENT_MCP_TIMEOUT` (default `30`) HTTP MCP request timeout in seconds.
 
 **Risks and Mitigations**
 1. Missing dependencies for FAISS

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -152,6 +152,51 @@ Start ACP with an MCP tool server:
 STUDY_AGENT_MCP_COMMAND=study-agent-mcp STUDY_AGENT_MCP_ARGS="" study-agent-acp
 ```
 
+This uses stdio MCP mode. If you use HTTP MCP, do not set `STUDY_AGENT_MCP_COMMAND`.
+
+HTTP MCP mode (recommended for cross-platform stability):
+
+```bash
+export MCP_TRANSPORT=http
+export MCP_HOST=127.0.0.1
+export MCP_PORT=8790
+export MCP_PATH=/mcp
+study-agent-mcp
+```
+
+Then in a second shell:
+
+```bash
+export STUDY_AGENT_MCP_URL="http://127.0.0.1:8790/mcp"
+study-agent-acp
+```
+
+Note: `STUDY_AGENT_MCP_URL` must include the port (e.g. `:8790`).
+When set, ACP uses HTTP and ignores `STUDY_AGENT_MCP_COMMAND`.
+
+PowerShell (Windows) MCP HTTP mode:
+
+```powershell
+$env:MCP_TRANSPORT = "http"
+$env:MCP_HOST = "127.0.0.1"
+$env:MCP_PORT = "8790"
+$env:MCP_PATH = "/mcp"
+study-agent-mcp
+```
+
+Then in a second PowerShell:
+
+```powershell
+$env:STUDY_AGENT_MCP_URL = "http://127.0.0.1:8790/mcp"
+study-agent-acp
+```
+
+Health check (PowerShell):
+
+```powershell
+Invoke-RestMethod -Uri http://127.0.0.1:8765/health
+```
+
 Recommended MCP environment (use absolute paths for stability):
 
 ```bash
@@ -282,6 +327,16 @@ Run the Python smoke test via `doit`:
 ```bash
 doit smoke_phenotype_flow
 ```
+
+If you want `doit` to spin up MCP over HTTP automatically, set:
+
+```bash
+export STUDY_AGENT_MCP_URL="http://127.0.0.1:8790/mcp"
+export STUDY_AGENT_MCP_MANAGED=1
+export MCP_START_TIMEOUT=3
+```
+
+Note: the smoke tasks set `ACP_URL` internally per flow. Avoid exporting a global `ACP_URL` unless you intend to override the target flow.
 
 ## Concept sets review smoke test
 

--- a/dodo.py
+++ b/dodo.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import subprocess
 import time
 import urllib.request
+from urllib.parse import urlparse
 
 ## NOTE: you also need LLM_API_KEY
 DEFAULT_ENV = {
@@ -17,10 +19,12 @@ DEFAULT_ENV = {
     "LLM_MODEL": os.getenv("LLM_MODEL", "gemma3:4b"),
     "LLM_TIMEOUT": os.getenv("LLM_TIMEOUT", "240"),
     "LLM_LOG": os.getenv("LLM_LOG", "1"),
+    "LLM_LOG_PROMPT": os.getenv("LLM_LOG_PROMPT", "0"),
+    "LLM_LOG_RESPONSE": os.getenv("LLM_LOG_RESPONSE", "0"),
+    "LLM_LOG_JSON": os.getenv("LLM_LOG_JSON", "0"),
     "LLM_DRY_RUN": os.getenv("LLM_DRY_RUN", "0"),
     "LLM_USE_RESPONSES": os.getenv("LLM_USE_RESPONSES", "0"),
     "LLM_CANDIDATE_LIMIT": os.getenv("LLM_CANDIDATE_LIMIT", "10"),
-    "ACP_URL": os.getenv("ACP_URL", "http://127.0.0.1:8765/flows/phenotype_recommendation"),
     "ACP_TIMEOUT": os.getenv("ACP_TIMEOUT", "180"),
     "STUDY_AGENT_HOST": os.getenv("STUDY_AGENT_HOST", "127.0.0.1"),
     "STUDY_AGENT_PORT": os.getenv("STUDY_AGENT_PORT", "8765"),
@@ -35,6 +39,54 @@ def _pytest_cmd(marker: str | None = None) -> str:
     if opts:
         return f"{base} {opts}"
     return base
+
+
+def _start_mcp_http_if_needed(env: dict) -> subprocess.Popen | None:
+    url = env.get("STUDY_AGENT_MCP_URL")
+    if not url:
+        return None
+    if env.get("STUDY_AGENT_MCP_MANAGED", "1") != "1":
+        return None
+    parsed = urlparse(url)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 8790
+    path = parsed.path or "/mcp"
+    env.setdefault("MCP_TRANSPORT", "http")
+    env.setdefault("MCP_HOST", host)
+    env.setdefault("MCP_PORT", str(port))
+    env.setdefault("MCP_PATH", path)
+    mcp_stdout = env.get("MCP_STDOUT", "/tmp/study_agent_mcp_stdout.log")
+    mcp_stderr = env.get("MCP_STDERR", "/tmp/study_agent_mcp_stderr.log")
+    print(f"Starting MCP over HTTP at {host}:{port}{path}...")
+    with open(mcp_stdout, "w", encoding="utf-8") as out, open(mcp_stderr, "w", encoding="utf-8") as err:
+        proc = subprocess.Popen(["study-agent-mcp"], env=env, stdout=out, stderr=err)
+    timeout_s = int(env.get("MCP_START_TIMEOUT", "10"))
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return proc
+        except OSError:
+            time.sleep(0.5)
+    print(f"Warning: MCP did not open {host}:{port} within {timeout_s}s")
+    return proc
+
+
+def _wait_for_acp(url: str, timeout_s: int = 30, require_mcp: bool = False) -> None:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as response:
+                if response.status == 200:
+                    if not require_mcp:
+                        return
+                    body = json.loads(response.read().decode("utf-8"))
+                    mcp_ok = isinstance(body.get("mcp"), dict) and body.get("mcp", {}).get("ok") is True
+                    if mcp_ok:
+                        return
+        except Exception:
+            time.sleep(0.5)
+    raise RuntimeError(f"ACP did not become ready at {url}")
 
 
 def task_install():
@@ -147,31 +199,23 @@ def task_list_services():
         if url.endswith("/"):
             url = url[:-1]
 
-        def _wait_for_acp(base_url: str, timeout_s: int = 15) -> None:
-            deadline = time.time() + timeout_s
-            health = f"{base_url}/health"
-            while time.time() < deadline:
-                try:
-                    with urllib.request.urlopen(health, timeout=2) as response:
-                        if response.status == 200:
-                            return
-                except Exception:
-                    time.sleep(0.5)
-            raise RuntimeError(f"ACP did not become ready at {health}")
-
         acp_proc = None
+        mcp_proc = None
         try:
             try:
-                _wait_for_acp(url, timeout_s=3)
+                _wait_for_acp(f"{url}/health", timeout_s=3)
             except Exception:
-                env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
-                env.setdefault("STUDY_AGENT_MCP_ARGS", "")
+                if not env.get("STUDY_AGENT_MCP_URL"):
+                    env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
+                    env.setdefault("STUDY_AGENT_MCP_ARGS", "")
+                mcp_proc = _start_mcp_http_if_needed(env)
                 acp_stdout = env.get("ACP_STDOUT", "/tmp/study_agent_acp_stdout.log")
                 acp_stderr = env.get("ACP_STDERR", "/tmp/study_agent_acp_stderr.log")
-                print("Starting ACP (will spawn MCP via stdio) to list services...")
+                print("Starting ACP to list services...")
                 with open(acp_stdout, "w", encoding="utf-8") as out, open(acp_stderr, "w", encoding="utf-8") as err:
                     acp_proc = subprocess.Popen(["study-agent-acp"], env=env, stdout=out, stderr=err)
-                _wait_for_acp(url, timeout_s=15)
+                require_mcp = bool(env.get("STUDY_AGENT_MCP_URL") or env.get("STUDY_AGENT_MCP_COMMAND"))
+                _wait_for_acp(f"{url}/health", timeout_s=15, require_mcp=require_mcp)
 
             req = urllib.request.Request(f"{url}/services")
             with urllib.request.urlopen(req, timeout=10) as response:
@@ -185,6 +229,13 @@ def task_list_services():
                     acp_proc.wait(timeout=10)
                 except subprocess.TimeoutExpired:
                     acp_proc.kill()
+            if mcp_proc is not None:
+                print("Stopping MCP...")
+                mcp_proc.terminate()
+                try:
+                    mcp_proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    mcp_proc.kill()
 
     return {
         "actions": [_run_list],
@@ -193,17 +244,6 @@ def task_list_services():
 
 
 def task_smoke_phenotype_recommend_flow():
-    def _wait_for_acp(url: str, timeout_s: int = 30) -> None:
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            try:
-                with urllib.request.urlopen(url, timeout=2) as response:
-                    if response.status == 200:
-                        return
-            except Exception:
-                time.sleep(0.5)
-        raise RuntimeError(f"ACP did not become ready at {url}")
-
     def _run_smoke() -> None:
         env = os.environ.copy()
         if not env.get("LLM_API_KEY"):
@@ -211,18 +251,24 @@ def task_smoke_phenotype_recommend_flow():
             return
         for key, value in DEFAULT_ENV.items():
             env.setdefault(key, value)
-        env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
-        env.setdefault("STUDY_AGENT_MCP_ARGS", "")
+        if not env.get("STUDY_AGENT_MCP_URL"):
+            env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
+            env.setdefault("STUDY_AGENT_MCP_ARGS", "")
         env.setdefault("LLM_LOG", "1")
+        env.setdefault("LLM_LOG_PROMPT", "1")
+        env.setdefault("LLM_LOG_RESPONSE", "1")
+        env["ACP_URL"] = "http://127.0.0.1:8765/flows/phenotype_recommendation"
         
         acp_stdout = env.get("ACP_STDOUT", "/tmp/study_agent_acp_stdout.log")
         acp_stderr = env.get("ACP_STDERR", "/tmp/study_agent_acp_stderr.log")
-        print("Starting ACP (will spawn MCP via stdio)...")
+        mcp_proc = _start_mcp_http_if_needed(env)
+        print("Starting ACP...")
         with open(acp_stdout, "w", encoding="utf-8") as out, open(acp_stderr, "w", encoding="utf-8") as err:
             acp_proc = subprocess.Popen(["study-agent-acp"], env=env, stdout=out, stderr=err)
         try:
             print("Waiting for ACP health endpoint...")
-            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30)
+            require_mcp = bool(env.get("STUDY_AGENT_MCP_URL") or env.get("STUDY_AGENT_MCP_COMMAND"))
+            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30, require_mcp=require_mcp)
             print("Running phenotype flow smoke test...")
             subprocess.run(["python", "tests/phenotype_flow_smoke_test.py"], check=True, env=env)
             print(f"ACP logs: {acp_stdout} {acp_stderr}")
@@ -233,6 +279,13 @@ def task_smoke_phenotype_recommend_flow():
                 acp_proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 acp_proc.kill()
+            if mcp_proc is not None:
+                print("Stopping MCP...")
+                mcp_proc.terminate()
+                try:
+                    mcp_proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    mcp_proc.kill()
 
     return {
         "actions": [_run_smoke],
@@ -241,17 +294,6 @@ def task_smoke_phenotype_recommend_flow():
 
 
 def task_smoke_phenotype_intent_split_flow():
-    def _wait_for_acp(url: str, timeout_s: int = 30) -> None:
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            try:
-                with urllib.request.urlopen(url, timeout=2) as response:
-                    if response.status == 200:
-                        return
-            except Exception:
-                time.sleep(0.5)
-        raise RuntimeError(f"ACP did not become ready at {url}")
-
     def _run_smoke() -> None:
         env = os.environ.copy()
         if not env.get("LLM_API_KEY"):
@@ -259,18 +301,24 @@ def task_smoke_phenotype_intent_split_flow():
             return
         for key, value in DEFAULT_ENV.items():
             env.setdefault(key, value)
-        env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
-        env.setdefault("STUDY_AGENT_MCP_ARGS", "")
+        if not env.get("STUDY_AGENT_MCP_URL"):
+            env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
+            env.setdefault("STUDY_AGENT_MCP_ARGS", "")
         env.setdefault("LLM_LOG", "1")
-
+        env.setdefault("LLM_LOG_PROMPT", "1")
+        env.setdefault("LLM_LOG_RESPONSE", "1")
+        env["ACP_URL"] = "http://127.0.0.1:8765/flows/phenotype_intent_split"
+        
         acp_stdout = env.get("ACP_STDOUT", "/tmp/study_agent_acp_stdout.log")
         acp_stderr = env.get("ACP_STDERR", "/tmp/study_agent_acp_stderr.log")
-        print("Starting ACP (will spawn MCP via stdio)...")
+        mcp_proc = _start_mcp_http_if_needed(env)
+        print("Starting ACP...")
         with open(acp_stdout, "w", encoding="utf-8") as out, open(acp_stderr, "w", encoding="utf-8") as err:
             acp_proc = subprocess.Popen(["study-agent-acp"], env=env, stdout=out, stderr=err)
         try:
             print("Waiting for ACP health endpoint...")
-            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30)
+            require_mcp = bool(env.get("STUDY_AGENT_MCP_URL") or env.get("STUDY_AGENT_MCP_COMMAND"))
+            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30, require_mcp=require_mcp)
             print("Running phenotype intent split flow smoke test...")
             subprocess.run(["python", "tests/phenotype_intent_split_smoke_test.py"], check=True, env=env)
             print(f"ACP logs: {acp_stdout} {acp_stderr}")
@@ -281,6 +329,13 @@ def task_smoke_phenotype_intent_split_flow():
                 acp_proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 acp_proc.kill()
+            if mcp_proc is not None:
+                print("Stopping MCP...")
+                mcp_proc.terminate()
+                try:
+                    mcp_proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    mcp_proc.kill()
 
     return {
         "actions": [_run_smoke],
@@ -289,17 +344,6 @@ def task_smoke_phenotype_intent_split_flow():
 
 
 def task_smoke_phenotype_improvements_flow():
-    def _wait_for_acp(url: str, timeout_s: int = 30) -> None:
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            try:
-                with urllib.request.urlopen(url, timeout=2) as response:
-                    if response.status == 200:
-                        return
-            except Exception:
-                time.sleep(0.5)
-        raise RuntimeError(f"ACP did not become ready at {url}")
-
     def _run_smoke() -> None:
         env = os.environ.copy()
         if not env.get("LLM_API_KEY"):
@@ -307,23 +351,26 @@ def task_smoke_phenotype_improvements_flow():
             return
         for key, value in DEFAULT_ENV.items():
             env.setdefault(key, value)
-        env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
-        env.setdefault("STUDY_AGENT_MCP_ARGS", "")
+        if not env.get("STUDY_AGENT_MCP_URL"):
+            env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
+            env.setdefault("STUDY_AGENT_MCP_ARGS", "")
 
         acp_stdout = env.get("ACP_STDOUT", "/tmp/study_agent_acp_stdout.log")
         acp_stderr = env.get("ACP_STDERR", "/tmp/study_agent_acp_stderr.log")
-        print("Starting ACP (will spawn MCP via stdio)...")
+        mcp_proc = _start_mcp_http_if_needed(env)
+        print("Starting ACP...")
         with open(acp_stdout, "w", encoding="utf-8") as out, open(acp_stderr, "w", encoding="utf-8") as err:
             acp_proc = subprocess.Popen(["study-agent-acp"], env=env, stdout=out, stderr=err)
         try:
             print("Waiting for ACP health endpoint...")
-            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30)
+            require_mcp = bool(env.get("STUDY_AGENT_MCP_URL") or env.get("STUDY_AGENT_MCP_COMMAND"))
+            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30, require_mcp=require_mcp)
             print("Running phenotype improvements flow smoke test...")
             payload = json.dumps(
                 {
                     "protocol_path": "demo/protocol.md",
                     "cohort_paths": [
-                        "demo/demo/test_git_event_cohort.json"
+                        "demo/test_git_event_cohort.json"
                     ],
                 }
             ).encode("utf-8")
@@ -348,6 +395,13 @@ def task_smoke_phenotype_improvements_flow():
                 acp_proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 acp_proc.kill()
+            if mcp_proc is not None:
+                print("Stopping MCP...")
+                mcp_proc.terminate()
+                try:
+                    mcp_proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    mcp_proc.kill()
 
     return {
         "actions": [_run_smoke],
@@ -356,17 +410,6 @@ def task_smoke_phenotype_improvements_flow():
 
 
 def task_smoke_phenotype_recommendation_advice_flow():
-    def _wait_for_acp(url: str, timeout_s: int = 30) -> None:
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            try:
-                with urllib.request.urlopen(url, timeout=2) as response:
-                    if response.status == 200:
-                        return
-            except Exception:
-                time.sleep(0.5)
-        raise RuntimeError(f"ACP did not become ready at {url}")
-
     def _run_smoke() -> None:
         env = os.environ.copy()
         if not env.get("LLM_API_KEY"):
@@ -374,24 +417,37 @@ def task_smoke_phenotype_recommendation_advice_flow():
             return
         for key, value in DEFAULT_ENV.items():
             env.setdefault(key, value)
-        env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
-        env.setdefault("STUDY_AGENT_MCP_ARGS", "")
+        if not env.get("STUDY_AGENT_MCP_URL"):
+            env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
+            env.setdefault("STUDY_AGENT_MCP_ARGS", "")
         env.setdefault("LLM_LOG", "1")
 
         acp_stdout = env.get("ACP_STDOUT", "/tmp/study_agent_acp_stdout.log")
         acp_stderr = env.get("ACP_STDERR", "/tmp/study_agent_acp_stderr.log")
-        print("Starting ACP (will spawn MCP via stdio)...")
+        mcp_proc = _start_mcp_http_if_needed(env)
+        print("Starting ACP...")
         with open(acp_stdout, "w", encoding="utf-8") as out, open(acp_stderr, "w", encoding="utf-8") as err:
             acp_proc = subprocess.Popen(["study-agent-acp"], env=env, stdout=out, stderr=err)
         try:
             print("Waiting for ACP health endpoint...")
-            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30)
+            require_mcp = bool(env.get("STUDY_AGENT_MCP_URL") or env.get("STUDY_AGENT_MCP_COMMAND"))
+            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30, require_mcp=require_mcp)
             print("Running phenotype recommendation advice flow smoke test...")
             subprocess.run(["python", "tests/phenotype_recommendation_advice_smoke_test.py"], check=True, env=env)
         finally:
             print("Stopping ACP...")
             acp_proc.terminate()
-            acp_proc.wait(timeout=10)
+            try:
+                acp_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                acp_proc.kill()
+            if mcp_proc is not None:
+                print("Stopping MCP...")
+                mcp_proc.terminate()
+                try:
+                    mcp_proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    mcp_proc.kill()
 
     return {
         "actions": [_run_smoke],
@@ -400,17 +456,6 @@ def task_smoke_phenotype_recommendation_advice_flow():
 
 
 def task_smoke_concept_sets_review_flow():
-    def _wait_for_acp(url: str, timeout_s: int = 30) -> None:
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            try:
-                with urllib.request.urlopen(url, timeout=2) as response:
-                    if response.status == 200:
-                        return
-            except Exception:
-                time.sleep(0.5)
-        raise RuntimeError(f"ACP did not become ready at {url}")
-
     def _run_smoke() -> None:
         env = os.environ.copy()
         if not env.get("LLM_API_KEY"):
@@ -418,18 +463,21 @@ def task_smoke_concept_sets_review_flow():
             return
         for key, value in DEFAULT_ENV.items():
             env.setdefault(key, value)
-        env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
-        env.setdefault("STUDY_AGENT_MCP_ARGS", "")
+        if not env.get("STUDY_AGENT_MCP_URL"):
+            env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
+            env.setdefault("STUDY_AGENT_MCP_ARGS", "")
         env.setdefault("LLM_LOG", "1")
 
         acp_stdout = env.get("ACP_STDOUT", "/tmp/study_agent_acp_stdout.log")
         acp_stderr = env.get("ACP_STDERR", "/tmp/study_agent_acp_stderr.log")
-        print("Starting ACP (will spawn MCP via stdio)...")
+        mcp_proc = _start_mcp_http_if_needed(env)
+        print("Starting ACP...")
         with open(acp_stdout, "w", encoding="utf-8") as out, open(acp_stderr, "w", encoding="utf-8") as err:
             acp_proc = subprocess.Popen(["study-agent-acp"], env=env, stdout=out, stderr=err)
         try:
             print("Waiting for ACP health endpoint...")
-            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30)
+            require_mcp = bool(env.get("STUDY_AGENT_MCP_URL") or env.get("STUDY_AGENT_MCP_COMMAND"))
+            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30, require_mcp=require_mcp)
             print("Running concept sets review flow smoke test...")
             payload = json.dumps(
                 {
@@ -458,6 +506,13 @@ def task_smoke_concept_sets_review_flow():
                 acp_proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 acp_proc.kill()
+            if mcp_proc is not None:
+                print("Stopping MCP...")
+                mcp_proc.terminate()
+                try:
+                    mcp_proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    mcp_proc.kill()
 
     return {
         "actions": [_run_smoke],
@@ -466,17 +521,6 @@ def task_smoke_concept_sets_review_flow():
 
 
 def task_smoke_cohort_critique_flow():
-    def _wait_for_acp(url: str, timeout_s: int = 30) -> None:
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            try:
-                with urllib.request.urlopen(url, timeout=2) as response:
-                    if response.status == 200:
-                        return
-            except Exception:
-                time.sleep(0.5)
-        raise RuntimeError(f"ACP did not become ready at {url}")
-
     def _run_smoke() -> None:
         env = os.environ.copy()
         if not env.get("LLM_API_KEY"):
@@ -484,18 +528,21 @@ def task_smoke_cohort_critique_flow():
             return
         for key, value in DEFAULT_ENV.items():
             env.setdefault(key, value)
-        env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
-        env.setdefault("STUDY_AGENT_MCP_ARGS", "")
+        if not env.get("STUDY_AGENT_MCP_URL"):
+            env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
+            env.setdefault("STUDY_AGENT_MCP_ARGS", "")
         env.setdefault("LLM_LOG", "1")
 
         acp_stdout = env.get("ACP_STDOUT", "/tmp/study_agent_acp_stdout.log")
         acp_stderr = env.get("ACP_STDERR", "/tmp/study_agent_acp_stderr.log")
-        print("Starting ACP (will spawn MCP via stdio)...")
+        mcp_proc = _start_mcp_http_if_needed(env)
+        print("Starting ACP...")
         with open(acp_stdout, "w", encoding="utf-8") as out, open(acp_stderr, "w", encoding="utf-8") as err:
             acp_proc = subprocess.Popen(["study-agent-acp"], env=env, stdout=out, stderr=err)
         try:
             print("Waiting for ACP health endpoint...")
-            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30)
+            require_mcp = bool(env.get("STUDY_AGENT_MCP_URL") or env.get("STUDY_AGENT_MCP_COMMAND"))
+            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30, require_mcp=require_mcp)
             print("Running cohort critique flow smoke test...")
             payload = json.dumps(
                 {
@@ -519,6 +566,13 @@ def task_smoke_cohort_critique_flow():
                 acp_proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 acp_proc.kill()
+            if mcp_proc is not None:
+                print("Stopping MCP...")
+                mcp_proc.terminate()
+                try:
+                    mcp_proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    mcp_proc.kill()
 
     return {
         "actions": [_run_smoke],
@@ -527,17 +581,6 @@ def task_smoke_cohort_critique_flow():
 
 
 def task_smoke_phenotype_validation_review_flow():
-    def _wait_for_acp(url: str, timeout_s: int = 30) -> None:
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            try:
-                with urllib.request.urlopen(url, timeout=2) as response:
-                    if response.status == 200:
-                        return
-            except Exception:
-                time.sleep(0.5)
-        raise RuntimeError(f"ACP did not become ready at {url}")
-
     def _run_smoke() -> None:
         env = os.environ.copy()
         if not env.get("LLM_API_KEY"):
@@ -545,18 +588,21 @@ def task_smoke_phenotype_validation_review_flow():
             return
         for key, value in DEFAULT_ENV.items():
             env.setdefault(key, value)
-        env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
-        env.setdefault("STUDY_AGENT_MCP_ARGS", "")
+        if not env.get("STUDY_AGENT_MCP_URL"):
+            env.setdefault("STUDY_AGENT_MCP_COMMAND", "study-agent-mcp")
+            env.setdefault("STUDY_AGENT_MCP_ARGS", "")
         env.setdefault("LLM_LOG", "1")
 
         acp_stdout = env.get("ACP_STDOUT", "/tmp/study_agent_acp_stdout.log")
         acp_stderr = env.get("ACP_STDERR", "/tmp/study_agent_acp_stderr.log")
-        print("Starting ACP (will spawn MCP via stdio)...")
+        mcp_proc = _start_mcp_http_if_needed(env)
+        print("Starting ACP...")
         with open(acp_stdout, "w", encoding="utf-8") as out, open(acp_stderr, "w", encoding="utf-8") as err:
             acp_proc = subprocess.Popen(["study-agent-acp"], env=env, stdout=out, stderr=err)
         try:
             print("Waiting for ACP health endpoint...")
-            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30)
+            require_mcp = bool(env.get("STUDY_AGENT_MCP_URL") or env.get("STUDY_AGENT_MCP_COMMAND"))
+            _wait_for_acp("http://127.0.0.1:8765/health", timeout_s=30, require_mcp=require_mcp)
             print("Running phenotype validation review flow smoke test...")
             payload = json.dumps(
                 {
@@ -597,6 +643,13 @@ def task_smoke_phenotype_validation_review_flow():
                 acp_proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 acp_proc.kill()
+            if mcp_proc is not None:
+                print("Stopping MCP...")
+                mcp_proc.terminate()
+                try:
+                    mcp_proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    mcp_proc.kill()
 
     return {
         "actions": [_run_smoke],

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -28,3 +28,19 @@ Keeper validation:
 - `keeper_parse_response`
 
 Authoring new MCP tools: see `docs/MCP_TOOL_AUTHORING.md`.
+
+## Running MCP over HTTP (recommended for cross-platform stability)
+
+```bash
+export MCP_TRANSPORT=http
+export MCP_HOST=127.0.0.1
+export MCP_PORT=8790
+export MCP_PATH=/mcp
+study-agent-mcp
+```
+
+ACP connects via:
+
+```bash
+export STUDY_AGENT_MCP_URL="http://127.0.0.1:8790/mcp"
+```

--- a/mcp_server/study_agent_mcp/server.py
+++ b/mcp_server/study_agent_mcp/server.py
@@ -46,8 +46,13 @@ def main() -> None:
     if transport in ("sse", "http"):
         host = os.getenv("MCP_HOST", "0.0.0.0")
         port = int(os.getenv("MCP_PORT", "3000"))
-        path = os.getenv("MCP_PATH", "/sse")
-        mcp.run(transport="streamable-http", host=host, port=port, path=path)
+        path = os.getenv("MCP_PATH", "/mcp")
+        mcp.settings.host = host
+        mcp.settings.port = port
+        mcp.settings.streamable_http_path = path
+        if os.getenv("MCP_LOG_LEVEL"):
+            mcp.settings.log_level = os.getenv("MCP_LOG_LEVEL", "INFO").upper()
+        mcp.run(transport="streamable-http")
     else:
         mcp.run()
 

--- a/mcp_server/study_agent_mcp/tools/_log.py
+++ b/mcp_server/study_agent_mcp/tools/_log.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+
+def _level_enabled(level: str) -> bool:
+    configured = os.getenv("MCP_LOG_LEVEL", "INFO").upper()
+    levels = {"DEBUG": 10, "INFO": 20, "WARN": 30, "WARNING": 30, "ERROR": 40, "OFF": 100}
+    if levels.get(level, 20) < levels.get(configured, 20):
+        return False
+    if levels.get(configured, 20) >= levels["OFF"]:
+        return False
+    return True
+
+
+def log_debug(message: str, **fields: Any) -> None:
+    if not _level_enabled("DEBUG"):
+        return
+    extras = ""
+    if fields:
+        extras = " " + " ".join([f"{k}={v}" for k, v in fields.items()])
+    print(f"MCP DEBUG > {message}{extras}", file=sys.stderr)

--- a/mcp_server/study_agent_mcp/tools/phenotype_search.py
+++ b/mcp_server/study_agent_mcp/tools/phenotype_search.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import os
+import time
 from typing import Any, Dict, Optional
 
 from study_agent_mcp.retrieval import get_default_index, index_status
 
 from ._common import with_meta
+from ._log import log_debug
 
 
 def register(mcp: object) -> None:
@@ -25,8 +27,25 @@ def register(mcp: object) -> None:
             dense_weight = default_dense_weight
         if sparse_weight is None:
             sparse_weight = default_sparse_weight
+        log_debug(
+            "phenotype_search start",
+            query_len=len(query or ""),
+            top_k=top_k,
+            dense_k=dense_k,
+            sparse_k=sparse_k,
+            dense_weight=dense_weight,
+            sparse_weight=sparse_weight,
+        )
         try:
+            t0 = time.time()
             index = get_default_index()
+            log_debug(
+                "phenotype_search index_loaded",
+                seconds=round(time.time() - t0, 3),
+                dense_loaded=getattr(index, "_dense", None) is not None,
+                sparse_loaded=getattr(index, "_sparse", None) is not None,
+                catalog_count=len(getattr(index, "catalog", []) or []),
+            )
         except Exception as exc:
             return with_meta(
                 {
@@ -37,6 +56,7 @@ def register(mcp: object) -> None:
                 "phenotype_search",
             )
         try:
+            t1 = time.time()
             results = index.search(
                 query=query,
                 top_k=top_k,
@@ -45,6 +65,11 @@ def register(mcp: object) -> None:
                 sparse_k=sparse_k,
                 dense_weight=dense_weight,
                 sparse_weight=sparse_weight,
+            )
+            log_debug(
+                "phenotype_search done",
+                seconds=round(time.time() - t1, 3),
+                result_count=len(results),
             )
         except Exception as exc:
             return with_meta(


### PR DESCRIPTION
  - Add HTTP MCP client and config (STUDY_AGENT_MCP_URL/TOKEN/TIMEOUT)
  - Make MCP HTTP startup stable across versions (settings-based host/port/path)
  - Add phenotype_index_status tool + index preflight checks
  - Add MCP probe script and richer LLM/debug logging
  - Update doit smoke tasks for HTTP MCP, readiness checks, and correct ACP_URL
  - Refresh docs for HTTP MCP setup and troubleshooting